### PR TITLE
Rename navigations -> navigation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/client/components/layouts.main/index.jsx
+++ b/client/components/layouts.main/index.jsx
@@ -13,7 +13,7 @@ const Layout = ({content = () => null }) => (
     </div>
 
     <footer>
-    <small>Built with <a href='https://github.com/kadirahq/mantra'>Mantra</a> & Meteor.</small>
+    <small>Built with <a href='https://github.com/kadirahq/mantra'>Mantra</a> & <a href='https://meteor.com'>Meteor</a>.</small>
     </footer>
   </div>
 );

--- a/client/components/layouts.main/index.jsx
+++ b/client/components/layouts.main/index.jsx
@@ -1,11 +1,11 @@
-import Navigations from '../navigations/index.jsx';
+import Navigation from '../navigation/index.jsx';
 import React from 'react';
 
 const Layout = ({content = () => null }) => (
   <div>
     <header>
     <h1>Mantra Voice</h1>
-    <Navigations />
+    <Navigation />
     </header>
 
     <div>

--- a/client/components/layouts.main/tests/index.js
+++ b/client/components/layouts.main/tests/index.js
@@ -2,20 +2,20 @@ const { describe, it } = global;
 import {expect} from 'chai';
 import {shallow} from 'enzyme';
 import MainLayout from '../index.jsx';
-import Navigations from '../../navigations/index.jsx';
+import Navigation from '../../navigation/index.jsx';
 
 describe('components.layouts.main', () => {
-  it('should contain navigations', () => {
+  it('should contain navigation', () => {
     const el = shallow(<MainLayout />);
-    expect(el.contains(Navigations)).to.be.equal(true);
+    expect(el.contains(Navigation)).to.be.equal(true);
   });
 
   it('should render childrens', () => {
     const Comp = () => (<p>Hello</p>);
     const el = shallow(
-      <Navigations>
+      <Navigation>
         <Comp />
-      </Navigations>
+      </Navigation>
     );
 
     expect(el.contains(Comp)).to.be.equal(true);

--- a/client/components/navigation/index.jsx
+++ b/client/components/navigation/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-const Navigations = () => (
+const Navigation = () => (
   <div>
-    <b> Navigations: </b>
+    <b> Navigation: </b>
     <a href="/">Home</a> |
     <a href="/new-post">New Post</a>
   </div>
 );
 
-export default Navigations;
+export default Navigation;

--- a/client/components/navigation/tests/index.js
+++ b/client/components/navigation/tests/index.js
@@ -1,18 +1,18 @@
 const { describe, it } = global;
 import {expect} from 'chai';
 import {shallow} from 'enzyme';
-import Navigations from '../index.jsx';
+import Navigation from '../index.jsx';
 
-describe('components.navigations', () => {
+describe('components.navigation', () => {
   it('should contain a link to home', () => {
-    const el = shallow(<Navigations />);
+    const el = shallow(<Navigation />);
     const homeLink = el.find('a').at(0);
     expect(homeLink.text()).to.be.equal('Home');
     expect(homeLink.prop('href')).to.be.equal('/');
   });
 
   it('should contain a link to create a new post', () => {
-    const el = shallow(<Navigations />);
+    const el = shallow(<Navigation />);
     const newPostLink = el.find('a').at(1);
     expect(newPostLink.text()).to.be.equal('New Post');
     expect(newPostLink.prop('href')).to.be.equal('/new-post');


### PR DESCRIPTION
'Navigations' feels funny to me, I think calling them 'navigation' is "better" English usage. I wish I could say with more confidence what I think is "wrong" about it…