### PR TITLE
Update posts.js

### DIFF
--- a/server/methods/posts.js
+++ b/server/methods/posts.js
@@ -9,7 +9,7 @@ export default function () {
       check(title, String);
       check(content, String);
 
-      // Show the latency compensations
+      // Demo the latency compensations (Delete this in production)
       Meteor._sleepForMs(500);
 
       // XXX: Do some user authorization


### PR DESCRIPTION
It may be best to help new Meteor developers by telling them to delete the _sleepForMs() method in production, encase they don't know what it does.