### PR TITLE
Update readme for users running Storybook with npm 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ This app is setup for [React Storybook](https://github.com/kadirahq/react-storyb
 ```
 npm run storybook
 ```
+
+**NOTE:** If this gives you missing module errors, React Storybook requires npm v3 - you can install it with
+
+```
+npm install -g npm3
+```
+
+delete your existing node_modules folder, and then run 
+
+```
+npm3 install && npm run storybook 
+```
+
+to get a working storybook running


### PR DESCRIPTION
Tried to fix the module structure for npm v2; but seems that babel api changes are incompatible with the old module structure,  so I just added instructions for fixing the issue for other npm 2 users