### PR TITLE
Fix newpost composer test

### DIFF
--- a/client/modules/core/containers/tests/newpost.js
+++ b/client/modules/core/containers/tests/newpost.js
@@ -26,7 +26,7 @@ describe('core.containers.newpost', () => {
       const args = onData.args[0];
 
       expect(args[0]).to.be.equal(null);
-      expect(args[1]).to.be.deep.equal({error: 'error'});
+      expect(args[1]).to.deep.equal({error: 'error'});
     });
 
     it('should return clearErrors', () => {


### PR DESCRIPTION
The new post composer tests had `to.be.deep.equal` rather than `to.deep.equal`.