### PR TITLE
use composeAllWithStub fix nested container issue

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@kadira/storybook';
-import { disable } from 'react-komposer';
+import { setTestMode } from 'react-komposer';
 
-disable();
+setTestMode();
 
 function loadStories() {
   require('../client/modules/core/components/.stories');

--- a/client/modules/comments/containers/comment_list.js
+++ b/client/modules/comments/containers/comment_list.js
@@ -1,7 +1,8 @@
 import {
-  useDeps, composeWithTracker, composeAll
+  useDeps, composeWithTracker, compose, composeAll
 } from 'mantra-core';
 import Component from '../components/comment_list';
+import { composeAllWithStub } from 'react-komposer';
 
 export const composer = ({context, clearErrors, postId}, onData) => {
   const {Meteor, Collections} = context();
@@ -16,7 +17,17 @@ export const composer = ({context, clearErrors, postId}, onData) => {
   }
 };
 
-export default composeAll(
+export const composerStub = ({context, clearErrors}, onData) => {
+  const comments = [
+    {_id: 'one', text: 'This is cool.', author: 'arunoda'},
+    {_id: 'two', text: 'Yeah! I agree.', author: 'sacha'},
+  ];
+
+  onData(null, {comments});
+};
+export default composeAllWithStub([
   composeWithTracker(composer),
   useDeps()
-)(Component);
+],[
+  compose(composerStub),
+])(Component);

--- a/client/modules/comments/containers/create_comment.js
+++ b/client/modules/comments/containers/create_comment.js
@@ -1,7 +1,8 @@
 import {
-  useDeps, composeWithTracker, composeAll
+  useDeps, composeWithTracker, compose, composeAll
 } from 'mantra-core';
 import Component from '../components/create_comment';
+import { composeAllWithStub } from 'react-komposer';
 
 export const composer = ({context, clearErrors}, onData) => {
   const {LocalState} = context();
@@ -17,7 +18,21 @@ export const depsMapper = (context, actions) => ({
   context: () => context
 });
 
-export default composeAll(
+export const composerStub = ({context, clearErrors}, onData) => {
+  onData(null, 'data`');
+  return clearErrors;
+};
+
+export const depsMapperStub = (context, actions) => ({
+  create: (x)=>console.log('create',x),
+  clearErrors: (x)=>console.log('clearErrors',x),
+  context: () => context
+});
+
+export default composeAllWithStub([
   composeWithTracker(composer),
   useDeps(depsMapper)
-)(Component);
+],[
+  compose(composerStub),
+  useDeps(depsMapperStub)
+])(Component);


### PR DESCRIPTION
use composeAllWithStub defined in PR kadirahq/react-storybook#85 instead of disable(). This enables proper rendering of the nested container components. Specifically:
- story comments.CommentList now shows the CreateComment properly
- story core.Post now shows the CommentList properly

This PR addresses kadirahq/react-storybook#45.